### PR TITLE
Add trailing particle option

### DIFF
--- a/src/main/java/cn/ussshenzhou/madparticle/command/MadParticleCommand.java
+++ b/src/main/java/cn/ussshenzhou/madparticle/command/MadParticleCommand.java
@@ -3,6 +3,7 @@ package cn.ussshenzhou.madparticle.command;
 import cn.ussshenzhou.madparticle.command.inheritable.*;
 import cn.ussshenzhou.madparticle.network.MadParticlePacket;
 import cn.ussshenzhou.madparticle.network.MadParticleTadaPacket;
+import cn.ussshenzhou.madparticle.particle.TrailEffect;
 import cn.ussshenzhou.madparticle.particle.enums.ChangeMode;
 import cn.ussshenzhou.madparticle.particle.MadParticleOption;
 import cn.ussshenzhou.madparticle.particle.enums.ParticleRenderTypes;
@@ -209,7 +210,17 @@ public class MadParticleCommand {
         Vec3 posDiffuse = ct.getArgument("spawnDiffuse", WorldCoordinates.class).getPosition(sourceStack);
         Vec3 speed = ct.getArgument("spawnSpeed", WorldCoordinates.class).getPosition(sourceStack);
         Vec3 speedDiffuse = ct.getArgument("speedDiffuse", WorldCoordinates.class).getPosition(sourceStack);
-        boolean haveChild = index != commandStrings.length - 1;
+        boolean hasNextChild = index != commandStrings.length - 1;
+        MadParticleOption nextChild = hasNextChild ? child : null;
+        if (metaTag.getBoolean("trail")) {
+            float tr = metaTag.getFloat("trailR");
+            float tg = metaTag.getFloat("trailG");
+            float tb = metaTag.getFloat("trailB");
+            int tl = metaTag.getInt("trailLife");
+            int ta = metaTag.getInt("trailAmount");
+            nextChild = TrailEffect.build(tr, tg, tb, tl, ta, nextChild);
+            hasNextChild = true;
+        }
         MadParticleOption father = new MadParticleOption(
                 BuiltInRegistries.PARTICLE_TYPE.getId(ct.getArgument("targetParticle", ParticleOptions.class).getType()),
                 ct.getArgument("spriteFrom", SpriteFrom.class),
@@ -239,8 +250,8 @@ public class MadParticleCommand {
                 ct.getArgument("beginScale", Float.class),
                 ct.getArgument("endScale", Float.class),
                 ct.getArgument("scaleMode", ChangeMode.class),
-                haveChild,
-                haveChild ? child : null,
+                hasNextChild,
+                nextChild,
                 ct.getArgument("rollSpeed", Float.class),
                 ct.getArgument("xDeflection", Float.class),
                 ct.getArgument("xDeflectionAfterCollision", Float.class),

--- a/src/main/java/cn/ussshenzhou/madparticle/designer/gui/panel/ParametersScrollPanel.java
+++ b/src/main/java/cn/ussshenzhou/madparticle/designer/gui/panel/ParametersScrollPanel.java
@@ -151,6 +151,15 @@ public class ParametersScrollPanel extends TScrollPanel {
             scaleBegin = new TTitledSimpleConstrainedEditBox(Component.translatable("gui.mp.de.helper.scale_begin"), FloatArgumentType.floatArg()),
             scaleEnd = new TTitledSimpleConstrainedEditBox(Component.translatable("gui.mp.de.helper.scale_end"), FloatArgumentType.floatArg());
 
+    // trail
+    public final TTitledCycleButton<Boolean> trail = new TTitledCycleButton<>(Component.translatable("gui.mp.de.helper.trail"));
+    public final TTitledSimpleConstrainedEditBox
+            trailLife = new TTitledSimpleConstrainedEditBox(Component.translatable("gui.mp.de.helper.trail_life"), IntegerArgumentType.integer(0)),
+            trailAmount = new TTitledSimpleConstrainedEditBox(Component.translatable("gui.mp.de.helper.trail_amount"), IntegerArgumentType.integer(0)),
+            trailR = new TTitledSimpleConstrainedEditBox(Component.translatable("gui.mp.de.helper.trail_r"), FloatArgumentType.floatArg()),
+            trailG = new TTitledSimpleConstrainedEditBox(Component.translatable("gui.mp.de.helper.trail_g"), FloatArgumentType.floatArg()),
+            trailB = new TTitledSimpleConstrainedEditBox(Component.translatable("gui.mp.de.helper.trail_b"), FloatArgumentType.floatArg());
+
     //meta
     public final MetaParameterPanel metaPanel = new MetaParameterPanel();
 
@@ -164,6 +173,7 @@ public class ParametersScrollPanel extends TScrollPanel {
         init6();
         init7();
         init8();
+        initTrail();
         //setChild(true);
         initTooltip();
         this.add(metaPanel);
@@ -300,6 +310,18 @@ public class ParametersScrollPanel extends TScrollPanel {
         this.addAll(bloomStrength, alpha, scale, alphaBegin, alphaEnd, scaleBegin, scaleEnd);
     }
 
+    public void initTrail() {
+        trail.addElement(Boolean.TRUE, b -> toggleTrail(true));
+        trail.addElement(Boolean.FALSE, b -> toggleTrail(false));
+        trail.getComponent().select(Boolean.FALSE);
+        this.addAll(trail, trailLife, trailAmount, trailR, trailG, trailB);
+        toggleTrail(false);
+    }
+
+    private void toggleTrail(boolean enable) {
+        Stream.of(trailLife, trailAmount, trailR, trailG, trailB).forEach(t -> t.setVisibleT(enable));
+    }
+
     @Override
     public void layout() {
         int xGap = 5;
@@ -391,9 +413,16 @@ public class ParametersScrollPanel extends TScrollPanel {
         LayoutHelper.BLeftOfA(alphaEnd, xGap, scale, stdTitledEditBox);
         LayoutHelper.BLeftOfA(alphaBegin, xGap, alphaEnd);
         LayoutHelper.BLeftOfA(alpha, xGap, alphaBegin, stdTitledButton);
+        //lane 9 - trail
+        LayoutHelper.BBottomOfA(trail, yGap, bloomStrength, stdTitledButton);
+        LayoutHelper.BRightOfA(trailLife, xGap, trail, stdTitledEditBox);
+        LayoutHelper.BRightOfA(trailAmount, xGap, trailLife, stdTitledEditBox);
+        LayoutHelper.BRightOfA(trailR, xGap, trailAmount, stdTitledEditBox);
+        LayoutHelper.BRightOfA(trailG, xGap, trailR, stdTitledEditBox);
+        LayoutHelper.BRightOfA(trailB, xGap, trailG, stdTitledEditBox);
         //meta
         metaPanel.passGap(xGap, yGap);
-        LayoutHelper.BBottomOfA(metaPanel, 2 * yGap, bloomStrength, getUsableWidth() - xGap, metaPanel.getPreferredSize().y);
+        LayoutHelper.BBottomOfA(metaPanel, 2 * yGap, trail, getUsableWidth() - xGap, metaPanel.getPreferredSize().y);
         super.layout();
     }
 
@@ -494,6 +523,8 @@ public class ParametersScrollPanel extends TScrollPanel {
                 ifClearThenSet(accessor.getAlpha(), alphaBegin, alphaEnd);
                 ifClearThenSet(String.format("%.2f", (accessor.getBbHeight() + accessor.getBbWidth()) / 2 / 0.2), scaleBegin, scaleEnd);
                 ifClearThenSet(bloomStrength, isChild ? "=" : "1");
+                trail.getComponent().select(Boolean.FALSE);
+                Stream.of(trailLife, trailAmount, trailR, trailG, trailB).forEach(e -> e.getComponent().setValue(""));
             }
         } catch (Exception ignored) {
         }
@@ -547,7 +578,20 @@ public class ParametersScrollPanel extends TScrollPanel {
         Stream.of(scaleBegin, scaleEnd).forEach(titled -> append(builder, titled));
         append(builder, scale);
         append(builder, whoCanSee.getComponent().getEditBox(), "@a");
-        metaPanel.wrap(builder);
+        StringBuilder meta = new StringBuilder();
+        metaPanel.wrap(meta);
+        if (trail.getComponent().getSelected() != null && trail.getComponent().getSelected().getContent()) {
+            int insert = meta.length() - 1;
+            if (insert > 1) {
+                meta.insert(insert, ',');
+            }
+            meta.insert(insert, "\"trail\":1,\"trailLife\":" + trailLife.getComponent().getValue()
+                    + ",\"trailAmount\":" + trailAmount.getComponent().getValue()
+                    + ",\"trailR\":" + trailR.getComponent().getValue()
+                    + ",\"trailG\":" + trailG.getComponent().getValue()
+                    + ",\"trailB\":" + trailB.getComponent().getValue());
+        }
+        builder.append(meta);
         return builder.toString();
     }
 

--- a/src/main/java/cn/ussshenzhou/madparticle/particle/TrailEffect.java
+++ b/src/main/java/cn/ussshenzhou/madparticle/particle/TrailEffect.java
@@ -1,0 +1,56 @@
+package cn.ussshenzhou.madparticle.particle;
+
+import cn.ussshenzhou.madparticle.command.inheritable.InheritableBoolean;
+import cn.ussshenzhou.madparticle.particle.enums.ChangeMode;
+import cn.ussshenzhou.madparticle.particle.enums.ParticleRenderTypes;
+import cn.ussshenzhou.madparticle.particle.enums.SpriteFrom;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Helper to build a simple trailing particle option.
+ */
+public class TrailEffect {
+    /**
+     * Build a trailing {@link MadParticleOption}.
+     *
+     * @param r        red color channel (0-1)
+     * @param g        green color channel (0-1)
+     * @param b        blue color channel (0-1)
+     * @param lifeTime lifetime of the trail particle
+     * @param amount   amount spawned each tick
+     * @param child    next child option, can be {@code null}
+     * @return configured {@link MadParticleOption}
+     */
+    public static MadParticleOption build(float r, float g, float b, int lifeTime, int amount, @Nullable MadParticleOption child) {
+        return new MadParticleOption(
+                BuiltInRegistries.PARTICLE_TYPE.getId(ParticleTypes.END_ROD),
+                SpriteFrom.AGE,
+                lifeTime,
+                InheritableBoolean.FALSE,
+                amount,
+                Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE,
+                0f, 0f, 0f,
+                0, 0, 0,
+                0f, 0f, 0f,
+                0f, 0f,
+                InheritableBoolean.FALSE, 0,
+                0f, 0f,
+                0f, 0f,
+                InheritableBoolean.FALSE,
+                0f, 0f,
+                ParticleRenderTypes.PARTICLE_SHEET_TRANSLUCENT,
+                r, g, b,
+                1f, 0f, ChangeMode.LINEAR,
+                0.25f, 0f, ChangeMode.LINEAR,
+                child != null, child,
+                0f,
+                0f, 0f,
+                0f, 0f,
+                1f,
+                new CompoundTag()
+        );
+    }
+}

--- a/src/main/resources/assets/madparticle/lang/en_us.json
+++ b/src/main/resources/assets/madparticle/lang/en_us.json
@@ -71,6 +71,12 @@
   "gui.mp.de.helper.scale": "Scale",
   "gui.mp.de.helper.scale_begin": "Initial",
   "gui.mp.de.helper.scale_end": "Final",
+  "gui.mp.de.helper.trail": "Trail",
+  "gui.mp.de.helper.trail_life": "Trail Life",
+  "gui.mp.de.helper.trail_amount": "Trail Amt.",
+  "gui.mp.de.helper.trail_r": "Trail R",
+  "gui.mp.de.helper.trail_g": "Trail G",
+  "gui.mp.de.helper.trail_b": "Trail B",
   "gui.mp.de.helper.unwrap": "Unwrap",
   "gui.mp.de.helper.bloom_factor": "Ext.Light",
 

--- a/src/main/resources/assets/madparticle/lang/zh_cn.json
+++ b/src/main/resources/assets/madparticle/lang/zh_cn.json
@@ -71,6 +71,12 @@
   "gui.mp.de.helper.scale": "大小变化",
   "gui.mp.de.helper.scale_begin": "初始大小",
   "gui.mp.de.helper.scale_end": "结束大小",
+  "gui.mp.de.helper.trail": "拖尾",
+  "gui.mp.de.helper.trail_life": "拖尾寿命",
+  "gui.mp.de.helper.trail_amount": "拖尾数量",
+  "gui.mp.de.helper.trail_r": "拖尾红",
+  "gui.mp.de.helper.trail_g": "拖尾绿",
+  "gui.mp.de.helper.trail_b": "拖尾蓝",
   "gui.mp.de.helper.unwrap": "解析",
   "gui.mp.de.helper.bloom_factor": "额外亮度",
 


### PR DESCRIPTION
## Summary
- add `TrailEffect` helper to build trailing particles
- expose trail configuration in parameter panel
- encode trail settings into meta and handle them in command builder
- include new trail translations

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684efc5812e48322b61aaf5413cbee9a